### PR TITLE
Set K3S submodule branches in prepare script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/k3s/prepare.sh
+++ b/k3s/prepare.sh
@@ -9,6 +9,8 @@
 set -euo pipefail
 
 PROXY_PORT="${PROXY_PORT:-7890}"          # ClashX local port
+SUBMODULE_BRANCH="${SUBMODULE_BRANCH:-k3s}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 c_grn=$'\033[32m'; c_red=$'\033[31m'; c_yel=$'\033[33m'; c_dim=$'\033[2m'; c_off=$'\033[0m'
 log()  { echo "${c_grn}▶${c_off} $*"; }
 info() { echo "${c_dim}  $*${c_off}"; }
@@ -16,6 +18,64 @@ warn() { echo "${c_yel}! $*${c_off}"; }
 die()  { echo "${c_red}✖ $*${c_off}" >&2; exit 1; }
 
 export PATH="/opt/homebrew/bin:$PATH"
+export SUBMODULE_BRANCH
+export ROOT
+
+# Switch each submodule to the branch used by the K3S setup.
+log "submodule branches"
+git -C "$ROOT" submodule sync --recursive
+git -C "$ROOT" submodule init
+git -C "$ROOT" submodule status --recursive | awk '/^-/{print $2}' | while read -r submodule_path; do
+  git -C "$ROOT" submodule update --init --recursive -- "$submodule_path"
+done
+missing_file="$ROOT/.missing-submodule-branches"
+dirty_file="$ROOT/.dirty-submodule-branches"
+rm -f "$missing_file" "$dirty_file"
+trap 'rm -f "$missing_file" "$dirty_file"' EXIT
+export missing_file dirty_file
+git -C "$ROOT" submodule foreach --recursive '
+  echo "  $name -> $SUBMODULE_BRANCH"
+  git ls-remote --exit-code --heads origin "$SUBMODULE_BRANCH" >/dev/null
+  ls_remote_status=$?
+  case "$ls_remote_status" in
+    0) ;;
+    2)
+      echo "$name" >> "$missing_file"
+      echo "  missing origin/$SUBMODULE_BRANCH"
+      exit 0
+      ;;
+    *)
+      echo "  failed to check origin/$SUBMODULE_BRANCH"
+      exit "$ls_remote_status"
+      ;;
+  esac
+
+  git fetch origin "$SUBMODULE_BRANCH"
+  checkout_log="$(mktemp)"
+  if git show-ref --verify --quiet "refs/heads/$SUBMODULE_BRANCH"; then
+    git checkout -q "$SUBMODULE_BRANCH" >"$checkout_log" 2>&1
+    checkout_status=$?
+  else
+    git checkout -q -b "$SUBMODULE_BRANCH" --track "origin/$SUBMODULE_BRANCH" >"$checkout_log" 2>&1
+    checkout_status=$?
+  fi
+  if [ "$checkout_status" -ne 0 ]; then
+    echo "$name" >> "$dirty_file"
+    echo "  could not switch to $SUBMODULE_BRANCH; clean or stash local changes"
+    rm -f "$checkout_log"
+    exit 0
+  fi
+  rm -f "$checkout_log"
+  git pull --ff-only --quiet origin "$SUBMODULE_BRANCH"
+'
+if [ -s "$dirty_file" ]; then
+  dirty_submodule_branches="$(cat "$dirty_file")"
+  die "could not switch submodule(s) to $SUBMODULE_BRANCH: ${dirty_submodule_branches//$'\n'/, }"
+fi
+if [ -s "$missing_file" ]; then
+  missing_submodule_branches="$(cat "$missing_file")"
+  die "missing origin/$SUBMODULE_BRANCH branch in submodule(s): ${missing_submodule_branches//$'\n'/, }"
+fi
 
 # ── 1. Host tools (Homebrew) ────────────────────────────────────────────────
 log "host tools"


### PR DESCRIPTION
## Summary

This PR updates `k3s/prepare.sh` so the K3S preparation step handles submodule branch setup automatically.

The script now:
- syncs submodule URLs from `.gitmodules`
- initializes missing submodules
- checks each submodule for an `origin/k3s` branch
- switches submodules that have `origin/k3s` to a local `k3s` branch
- creates a local tracking branch when `k3s` does not already exist locally
- pulls the latest `k3s` branch using fast-forward only
- reports submodules that do not have an `origin/k3s` branch
- stops the setup when required `k3s` branches are missing
I also added `.gitattributes` with:

```gitattributes
*.sh text eol=lf
```

This keeps shell scripts using LF line endings across Windows, macOS, and Linux, preventing Bash errors caused by CRLF conversion.

## Testing

Tested locally with:

```bash
bash -n k3s/prepare.sh
git diff --check -- k3s/prepare.sh .gitattributes
bash k3s/prepare.sh
```

The script successfully fetched and switched the following submodules that have an `origin/k3s` branch:

* `bulk-pack-processor`
* `bulk-pack-transformer-v2`
* `images-api`
* `treetracker-admin-api`
* `treetracker-admin-client`
* `treetracker-api`
* `treetracker-field-data`

The script also clearly reported the following submodules that currently do not have an `origin/k3s` branch:

* `bulk-pack-consumer`
* `bulk-pack-transformer`
* `treetracker-android`
* `treetracker-database`
* `treetracker-infrastructure`
* `treetracker-query-api`
* `treetracker-wallet-api`
* `treetracker-wallet-app`
* `treetracker-web-map-client`

## Screenshots

The screenshots below show the script syncing submodules, fetching available `k3s` branches, switching the supported submodules, and reporting repositories where `origin/k3s` is missing.

<!-- Screenshot showing submodule synchronization and branch switching -->

<img width="1146" height="1450" alt="Submodule synchronization and k3s branch switching" src="https://github.com/user-attachments/assets/4e428e5c-2506-44c7-94d0-78d323d9f15f" />

<!-- Screenshot showing missing origin/k3s branches -->

<img width="2524" height="1098" alt="Missing origin k3s branches reported by prepare.sh" src="https://github.com/user-attachments/assets/40878d09-dcc9-4256-8576-3b66f9f392fe" />

Closes #6
