### PR TITLE
feat: deploy wallet app in local k3s

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "treetracker-wallet-app"]
 	path = treetracker-wallet-app
-	url = git@github.com:Amaanfaiz/treetracker-wallet-app.git
+	url = git@github.com:Greenstand/treetracker-wallet-app.git
 [submodule "treetracker-database"]
 	path = treetracker-database
 	url = git@github.com:Greenstand/treetracker-database.git

--- a/k3s/README.md
+++ b/k3s/README.md
@@ -9,7 +9,7 @@ clusters.
 ```bash
 ./k3s/prepare.sh     # ONCE per machine (macOS-specific): install tools (k3d/helm/awscli/libpq).
 ./k3s/up.sh          # portable, idempotent: bring up the whole stack. Re-run to repair/continue.
-                     #   single step: ./k3s/up.sh gateway | field_data | treetracker_api | admin_client | ...
+                     #   single step: ./k3s/up.sh gateway | field_data | treetracker_api | admin_client | wallet_app | ...
 ./k3s/down.sh        # tear down: delete the k3d cluster (all pods + data).
                      #   ./k3s/down.sh --namespaces   (keep cluster, drop stack namespaces)
                      #   ./k3s/down.sh --images        (also remove built/pulled images)
@@ -170,6 +170,17 @@ Emissary), routed by each service's **shipped `getambassador.io` Mapping** (`/ap
 Mapping. `up.sh step_gateway` installs Emissary (CRDs + helm) and a `Listener` + wildcard `Host`
 (`k3s/emissary.yaml`) **before** the service overlays (which now keep their Mappings). No per-service
 port-forward, no nginx reverse-proxy (admin-client nginx serves static only); single origin ⇒ no CORS.
+
+## Wallet web app
+The wallet monorepo's `apps/web` workspace is built as a static Next.js export and served by nginx
+behind Emissary at **`http://localhost:8088/wallet/`**. Its local image and deployment can be repaired
+or updated independently:
+```bash
+./k3s/up.sh wallet_app
+```
+The build sets the Next.js base path to `/wallet`; Emissary strips that prefix before forwarding to
+the wallet-app Service. Authentication and wallet API calls use the development Keycloak/user/wallet
+endpoints configured as build arguments in `treetracker-wallet-app/deployment/local/Dockerfile`.
 
 ## Status
 **Done — full capture→verify stack, `apps/e2e` `03_capture_setup` passes 19/19** (via the Ambassador

--- a/k3s/down.sh
+++ b/k3s/down.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 ENV="${ENV:-local}"
 CLUSTER="${CLUSTER:-greenstand}"
 CONTEXT="${KUBE_CONTEXT:-k3d-$CLUSTER}"
-NAMESPACES=(admin-client admin-api bulk-pack-services treetracker-api images-api field-data-api rabbitmq data emissary emissary-system)
+NAMESPACES=(wallet-app admin-client admin-api bulk-pack-services treetracker-api images-api field-data-api rabbitmq data emissary emissary-system)
 
 export PATH="/opt/homebrew/bin:$PATH"
 export NO_PROXY="0.0.0.0,127.0.0.1,localhost,::1,.svc,.cluster.local"
@@ -61,7 +61,7 @@ fi
 
 if [ "$CLEAN_IMAGES" = 1 ]; then
   log "removing local images"
-  docker rmi -f treetracker-field-data:local treetracker-api:local images-api:local bulk-pack-transformer-v2:local bulk-pack-processor:local bulk-pack-consumer:local treetracker-admin-api:local treetracker-admin-client:local postgis/postgis:15-3.4 rabbitmq:3.13-management 2>/dev/null || true
+  docker rmi -f treetracker-wallet-app:local treetracker-field-data:local treetracker-api:local images-api:local bulk-pack-transformer-v2:local bulk-pack-processor:local bulk-pack-consumer:local treetracker-admin-api:local treetracker-admin-client:local postgis/postgis:15-3.4 rabbitmq:3.13-management 2>/dev/null || true
 fi
 
 log "down complete"

--- a/k3s/up.sh
+++ b/k3s/up.sh
@@ -23,6 +23,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 K3S_DIR="$ROOT/k3s"
 NEXTGEN="$ROOT/treetracker-database-nextgen"
 ADMIN_CLIENT="$ROOT/treetracker-admin-client"
+WALLET_APP="$ROOT/treetracker-wallet-app"
 ADMIN_CLIENT_PORT="${ADMIN_CLIENT_PORT:-3001}"   # host port-forward → admin-client pod (ADMIN_URL for the e2e)
 
 export PATH="/opt/homebrew/bin:$PATH"
@@ -271,6 +272,16 @@ step_admin_client() {
   [ "$ENV" = local ] && check_gateway
 }
 
+step_wallet_app() {
+  log "treetracker-wallet-app (static Next.js export → /wallet)"
+  docker build -t treetracker-wallet-app:local -f "$WALLET_APP/deployment/local/Dockerfile" "$WALLET_APP" \
+    >/tmp/up-walletapp-build.log 2>&1 || die "wallet-app image build failed (see /tmp/up-walletapp-build.log)"
+  load_image "treetracker-wallet-app:local"
+  k apply -f "$WALLET_APP/deployment/local/k8s.yaml" >/dev/null
+  k -n wallet-app rollout status deploy/treetracker-wallet-app --timeout=180s
+  [ "$ENV" = local ] && check_wallet_gateway
+}
+
 # The gateway (Emissary via the k3d loadbalancer) is the single entry: http://localhost:8088.
 # No port-forward — routing is by the shipped Mappings (/api/admin/, /images/, …) + admin-client `/`.
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:8088}"
@@ -285,6 +296,16 @@ check_gateway() {
     -H 'Content-Type: application/json' -d "{\"userName\":\"${ADMIN_USER:-test}\",\"password\":\"${ADMIN_PASSWORD:-ieVyaGqyMX}\"}" 2>/dev/null || true)
   [ "$code" = 200 ] || die "gateway → admin-api login route not working ($GATEWAY_URL/api/admin/auth/login = $code)"
   info "ADMIN_URL=$GATEWAY_URL  (login: ${ADMIN_USER:-test} / ${ADMIN_PASSWORD:-ieVyaGqyMX}) — via Ambassador"
+}
+
+check_wallet_gateway() {
+  local i code
+  for i in $(seq 1 30); do
+    code=$(curl -s -o /dev/null -m 3 -w '%{http_code}' "$GATEWAY_URL/wallet/" 2>/dev/null || true)
+    [ "$code" = 200 ] && break; sleep 2
+  done
+  [ "$code" = 200 ] || die "gateway not serving wallet-app at $GATEWAY_URL/wallet/ (code=$code)"
+  info "WALLET_URL=$GATEWAY_URL/wallet/"
 }
 
 # Seed the legacy admin_user for the /verify login (username/password + HMAC-SHA512(pw,salt)).
@@ -317,7 +338,7 @@ run_all() {
   step_cluster; step_infra_images; step_postgres; step_migrate; step_rabbitmq
   step_gateway   # BEFORE service overlays — they ship Ambassador Mappings (need the CRDs)
   step_field_data; step_treetracker_api; step_transformer_v2; step_processor; step_consumer
-  step_admin; step_images_api; step_admin_client
+  step_admin; step_images_api; step_admin_client; step_wallet_app
   log "done — full capture→verify backend up on $CONTEXT (gateway: $GATEWAY_URL)"
 }
 
@@ -325,6 +346,6 @@ trap stop_pf EXIT
 step_preflight
 case "${1:-all}" in
   all) run_all ;;
-  cluster|infra_images|postgres|migrate|rabbitmq|gateway|field_data|treetracker_api|images_api|transformer_v2|processor|consumer|keycloak|admin|admin_client) "step_${1}" ;;
-  *)   die "unknown step '${1}'. steps: cluster infra_images postgres migrate rabbitmq gateway field_data treetracker_api images_api transformer_v2 processor consumer keycloak admin admin_client (or 'all')" ;;
+  cluster|infra_images|postgres|migrate|rabbitmq|gateway|field_data|treetracker_api|images_api|transformer_v2|processor|consumer|keycloak|admin|admin_client|wallet_app) "step_${1}" ;;
+  *)   die "unknown step '${1}'. steps: cluster infra_images postgres migrate rabbitmq gateway field_data treetracker_api images_api transformer_v2 processor consumer keycloak admin admin_client wallet_app (or 'all')" ;;
 esac


### PR DESCRIPTION
## Summary

- add a `wallet_app` deployment step to `k3s/up.sh`
- build, import, deploy, and readiness-check the wallet web image
- expose and health-check the wallet UI at `http://localhost:8088/wallet/`
- clean up the wallet namespace and image in `k3s/down.sh`
- document the standalone wallet deployment command
- update the wallet-app submodule to the deployment commit from Greenstand/treetracker-wallet-app#793

## Why

The local k3s environment currently deploys the backend and admin client but not the wallet web application requested in #8.

## Dependency

This PR depends on Greenstand/treetracker-wallet-app#793.

## Validation

- `bash -n k3s/up.sh k3s/down.sh`
- Kubernetes manifest YAML parsing
- `git diff --check`
- full Docker/k3s execution was intentionally deferred because the development machine does not currently have sufficient free disk space
